### PR TITLE
Fix a bug with wrong decomposition

### DIFF
--- a/quantum_decomp/quantum_decomp_main.py
+++ b/quantum_decomp/quantum_decomp_main.py
@@ -14,7 +14,7 @@ from .src.utils import PAULI_X, is_unitary, is_special_unitary, \
 def two_level_decompose(A):
     """Returns list of two-level unitary matrices, which multiply to A.
 
-    Matrices are listed in application order, i.e. if aswer is [u_1, u_2, u_3],
+    Matrices are listed in application order, i.e. if answer is [u_1, u_2, u_3],
     it means A = u_3 u_2 u_1.
 
     :param A: matrix to decompose.
@@ -25,6 +25,7 @@ def two_level_decompose(A):
         """Returns unitary matrix U, s.t. [a, b] U = [c, 0].
 
         Makes second element equal to zero.
+        Guarantees np.angle(c)=0.
         """
         assert (np.abs(a) > 1e-9 and np.abs(b) > 1e-9)
         theta = np.arctan(np.abs(b / a))
@@ -43,26 +44,38 @@ def two_level_decompose(A):
     n = A.shape[0]
     result = []
     # Make a copy, because we are going to mutate it.
-    A = np.array(A)
+    cur_A = np.array(A)
 
     for i in range(n - 2):
         for j in range(n - 1, i, -1):
-            if abs(A[i, j]) < 1e-9:
-                # Element is already zero, skipping.
-                pass
+            a = cur_A[i, j - 1]
+            b = cur_A[i, j]
+            if abs(cur_A[i, j]) < 1e-9:
+                # Element is already zero, nothing to do.
+                u_2x2 = IDENTITY_2x2
+                # But if it's last in row, ensure diagonal element will be 1.
+                if j == i + 1:
+                    u_2x2 = np.array([[1 / a, 0], [0, a]])
+            elif abs(cur_A[i, j - 1]) < 1e-9:
+                # Just swap columns.
+                u_2x2 = PAULI_X
+                # But if it's last in row, ensure diagonal element will be 1.
+                if j == i + 1:
+                    u_2x2 = np.array([[0, b], [1 / b, 0]])
             else:
-                if abs(A[i, j - 1]) < 1e-9:
-                    # Just swap columns.
-                    u_2x2 = PAULI_X
-                else:
-                    u_2x2 = make_eliminating_matrix(A[i, j - 1], A[i, j])
-                u_2x2 = TwoLevelUnitary(u_2x2, n, j - 1, j)
-                u_2x2.multiply_right(A)
+                u_2x2 = make_eliminating_matrix(a, b)
+            u_2x2 = TwoLevelUnitary(u_2x2, n, j - 1, j)
+            u_2x2.multiply_right(cur_A)
+            if not u_2x2.is_identity():
                 result.append(u_2x2.inv())
 
-    last_matrix = A[n - 2:n, n - 2:n]
-    if not np.allclose(last_matrix, IDENTITY_2x2):
-        result.append(TwoLevelUnitary(last_matrix, n, n - 2, n - 1))
+        # After we are done with row, diagonal element is 1.
+        assert np.allclose(cur_A[i, i], 1.0)
+
+    last_matrix = TwoLevelUnitary(cur_A[n - 2:n, n - 2:n], n, n - 2, n - 1)
+    if not last_matrix.is_identity():
+        result.append(last_matrix)
+
     return result
 
 

--- a/quantum_decomp/quantum_decomp_main.py
+++ b/quantum_decomp/quantum_decomp_main.py
@@ -14,8 +14,8 @@ from .src.utils import PAULI_X, is_unitary, is_special_unitary, \
 def two_level_decompose(A):
     """Returns list of two-level unitary matrices, which multiply to A.
 
-    Matrices are listed in application order, i.e. if answer is [u_1, u_2, u_3],
-    it means A = u_3 u_2 u_1.
+    Matrices are listed in application order, i.e. if answer is
+    [u_1, u_2, u_3], it means A = u_3 u_2 u_1.
 
     :param A: matrix to decompose.
     :return: The decomposition - list of two-level unitary matrices.

--- a/quantum_decomp/quantum_decomp_test.py
+++ b/quantum_decomp/quantum_decomp_test.py
@@ -161,7 +161,6 @@ class QuantumDecompTestCase(unittest.TestCase):
         _check(SWAP)
         _check(CNOT)
         _check(QFT_2)
-        _check(BAD_MATRIX)
 
         np.random.seed(100)
         for matrix_size in [2, 4, 8]:

--- a/quantum_decomp/quantum_decomp_test.py
+++ b/quantum_decomp/quantum_decomp_test.py
@@ -53,6 +53,28 @@ class QuantumDecompTestCase(unittest.TestCase):
                           [1, w * w, w]]) / np.sqrt(3)
         self.check_two_level_decompose(A)
 
+    # This test checks that two-level decomposition algorithm ensures that
+    # diagonal element is equal to 1 after we are done with a row.
+    def test_diagonal_elements_handled_correctly(self):
+        self.check_two_level_decompose(np.array([
+            [1j, 0, 0, 0],
+            [0, -1j, 0, 0],
+            [0, 0, -1j, 0],
+            [0, 0, 0, 1j],
+        ]))
+        self.check_two_level_decompose(np.array([
+            [1, 0, 0, 0],
+            [0, 0, 0, 1j],
+            [0, 0, 1, 0],
+            [0, 1j, 0, 0],
+        ]))
+        self.check_two_level_decompose(np.array([
+            [0, 0, 1j, 0],
+            [0, 1j, 0, 0],
+            [1j, 0, 0, 0],
+            [0, 0, 0, 1],
+        ]))
+
     def test_decompose_random(self):
         for matrix_size in range(2, 20):
             for i in range(4):
@@ -139,6 +161,7 @@ class QuantumDecompTestCase(unittest.TestCase):
         _check(SWAP)
         _check(CNOT)
         _check(QFT_2)
+        _check(BAD_MATRIX)
 
         np.random.seed(100)
         for matrix_size in [2, 4, 8]:

--- a/quantum_decomp/src/two_level_unitary.py
+++ b/quantum_decomp/src/two_level_unitary.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from quantum_decomp.src.utils import PAULI_X, is_unitary, is_power_of_two
+from quantum_decomp.src.utils import PAULI_X, is_unitary, IDENTITY_2x2
 
 
 class TwoLevelUnitary:
@@ -55,3 +55,6 @@ class TwoLevelUnitary:
         assert(len(perm) == self.matrix_size)
         self.index1 = perm[self.index1]
         self.index2 = perm[self.index2]
+
+    def is_identity(self):
+        return np.allclose(self.matrix_2x2, IDENTITY_2x2)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt', 'r', encoding='utf-8') as req_file:
 
 setuptools.setup(
     name="quantum_decomp",
-    version="1.1.0",
+    version="1.1.1",
     author="Dmytro Fedoriaka",
     description="Tool for decomposing unitary matrix into quantum gates",
     long_description=long_description,


### PR DESCRIPTION
Correctness of the algorithm depends on the fact that after we are done with a row, diagonal element in it is equal to 1.

This is true if last 2-level unitary was general case unitary (calculated using formulas). But there are 2 special cases: when we skip zero element and apply identity matrix and when we swap two elements and apply X matrix. In both these cases, if it happened on last step in a row, we might end up with an element on main diagonal which is not 1.

This PR adds a fix: if it's last matrix in a row, instead of I and X, apply matrices which will guarantee that diagonal element is 1. Instead of I - apply [[1/a, 0], [0, a]]. Instead of X - apply [[0, b], [1/b, 0]].

Alternative would be to not have special cases and handle them together with general case, which always guarantees that arg(c)=0. However, it's useful optimization in case of sparse matrix, to use I and X matrices in decomposition. I want to keep this optimization where it doesn't matter, and it matters only once per row.

Also this means that my paper has mistake. On page 2 it says "As our construction always makes c real and positive...", which is not true for algorithm described above. 